### PR TITLE
Prevents creation of mod notes if the user is not a moderator

### DIFF
--- a/app/controllers/conversations/messages_controller.rb
+++ b/app/controllers/conversations/messages_controller.rb
@@ -4,9 +4,7 @@ module Conversations
       @message = MessageCreator.create(
         conversation: conversation,
         author: @user,
-        body: params[:message][:body],
-        hat_id: params[:message][:hat_id],
-        create_modnote: create_modnote?,
+        params: message_params
       )
 
       if @message.persisted?
@@ -17,15 +15,11 @@ module Conversations
   private
 
     def message_params
-      params.require(:message).permit(:body, :hat_id)
+      params.require(:message).permit(:body, :hat_id, :mod_note)
     end
 
     def conversation
       @conversation ||= Conversation.find_by(short_id: params[:conversation_id])
-    end
-
-    def create_modnote?
-      params[:message][:mod_note] == "1"
     end
   end
 end

--- a/app/models/conversation_creator.rb
+++ b/app/models/conversation_creator.rb
@@ -1,45 +1,33 @@
 class ConversationCreator
-  def self.create(author:, recipient_username:, subject:, message_params: nil)
-    new.create(
-      author: author,
-      recipient_username: recipient_username,
-      subject: subject,
-      message_params: message_params,
-    )
-  end
+  class << self
+    def create(author:, recipient_username:, subject:, message_params: nil)
+      Conversation.create(
+        author: author,
+        recipient: recipient(recipient_username),
+        subject: subject,
+      ).tap do |conversation|
+        ensure_recipient(conversation: conversation, username: recipient_username)
 
-  def create(author:, recipient_username:, subject:, message_params: nil)
-    Conversation.create(
-      author: author,
-      recipient: recipient(recipient_username),
-      subject: subject,
-    ).tap do |conversation|
-      ensure_recipient(conversation: conversation, username: recipient_username)
-      if conversation.persisted?
-        MessageCreator.create(
-          conversation: conversation,
-          author: author,
-          body: message_params[:body],
-          hat_id: message_params[:hat_id],
-          create_modnote: create_modnote?(message_params),
-        )
+        if conversation.persisted?
+          MessageCreator.create(
+            conversation: conversation,
+            author: author,
+            params: message_params,
+          )
+        end
       end
     end
-  end
 
-private
+    private
 
-  def recipient(username)
-    @_recipient ||= User.find_by(username: username)
-  end
+      def recipient(username)
+        User.find_by(username: username)
+      end
 
-  def ensure_recipient(conversation:, username:)
-    if conversation.recipient.nil?
-      conversation.errors.add(:user, "Can't find user: #{username}")
-    end
-  end
-
-  def create_modnote?(message_params)
-    message_params[:mod_note] == "1"
+      def ensure_recipient(conversation:, username:)
+        if conversation.recipient.nil?
+          conversation.errors.add(:user, "Can't find user: #{username}")
+        end
+      end
   end
 end

--- a/app/models/message_creator.rb
+++ b/app/models/message_creator.rb
@@ -1,31 +1,23 @@
 class MessageCreator
-  def self.create(
-    conversation:,
-    author:,
-    body:,
-    hat_id: nil,
-    create_modnote: false
-  )
-    new.create(
-      conversation: conversation,
-      author: author,
-      body: body,
-      hat_id: hat_id,
-      create_modnote: create_modnote
-    )
-  end
-
-  def create(conversation:, author:, body:, hat_id: nil, create_modnote: false)
-    conversation.messages.create(
-      subject: conversation.subject,
-      author: author,
-      recipient: conversation.partner(of: author),
-      body: body,
-      hat_id: hat_id,
-    ).tap do |message|
-      if create_modnote
-        ModNote.create_from_message(message, author)
+  class << self
+    def create(conversation:, author:, params:)
+      conversation.messages.create(
+        subject: conversation.subject,
+        author: author,
+        recipient: conversation.partner(of: author),
+        body: params[:body],
+        hat_id: params[:hat_id],
+      ).tap do |message|
+        if create_modnote?(params) && author.is_moderator?
+          ModNote.create_from_message(message, author)
+        end
       end
     end
+
+    private
+
+      def create_modnote?(params)
+        params[:mod_note] == "1"
+      end
   end
 end

--- a/spec/models/conversation_spec.rb
+++ b/spec/models/conversation_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe Conversation do
         MessageCreator.create(
           conversation: conversation,
           author: conversation.author,
-          body: "hi",
+          params: { body: "hi" },
         )
       end
 

--- a/spec/models/message_creator_spec.rb
+++ b/spec/models/message_creator_spec.rb
@@ -7,10 +7,10 @@ RSpec.describe MessageCreator do
 
       conversation = create(:conversation)
 
-      message = MessageCreator.new.create(
+      message = MessageCreator.create(
         conversation: conversation,
         author: conversation.author,
-        body: "Hi"
+        params: { body: "Hi" }
       )
       conversation.reload
 
@@ -21,10 +21,10 @@ RSpec.describe MessageCreator do
     it "uses the conversation subject" do
       conversation = create(:conversation, subject: "Here I am")
 
-      message = MessageCreator.new.create(
+      message = MessageCreator.create(
         conversation: conversation,
         author: conversation.author,
-        body: "Hi"
+        params: { body: "Hi" }
       )
 
       expect(message.subject).to eq("Here I am")
@@ -35,15 +35,15 @@ RSpec.describe MessageCreator do
       user2 = create(:user)
       conversation = create(:conversation, author: user1, recipient: user2)
 
-      message1 = MessageCreator.new.create(
+      message1 = MessageCreator.create(
         conversation: conversation,
         author: user1,
-        body: "Hi"
+        params: { body: "Hi" }
       )
-      message2 = MessageCreator.new.create(
+      message2 = MessageCreator.create(
         conversation: conversation,
         author: user2,
-        body: "Hi, back"
+        params: { body: "Hi, back" }
       )
 
       expect(message1.recipient).to eq(user2)
@@ -57,8 +57,10 @@ RSpec.describe MessageCreator do
       message = MessageCreator.create(
         conversation: conversation,
         author: conversation.author,
-        body: "Hi",
-        hat_id: hat.id,
+        params: {
+          body: "Hi",
+          hat_id: hat.id,
+        }
       )
 
       expect(message.hat).to eq(hat)
@@ -70,12 +72,16 @@ RSpec.describe MessageCreator do
       conversation = create(:conversation)
       hat = create(:hat, :for_modnotes)
 
+      conversation.author.update(is_moderator: true)
+
       MessageCreator.create(
         conversation: conversation,
         author: conversation.author,
-        body: "Hi",
-        hat_id: hat.id,
-        create_modnote: true,
+        params: {
+          body: "Hi",
+          hat_id: hat.id,
+          mod_note: "1",
+        }
       )
 
       expect(ModNote.count).to eq(1)


### PR DESCRIPTION
Hi Edward, my apologies for taking some liberties with the code (see below), but this patch ensures that only moderators can add mod notes.

- Adds the check in message_creator.rb
- Moves responsibility for handling message parameters into MessageCreator
- Reduces indirection in Conversation and MessageCreator classes
